### PR TITLE
templateVersionId param added on session creation + session language is now returning on GET request

### DIFF
--- a/VStore.Host/Controllers/SessionsController.cs
+++ b/VStore.Host/Controllers/SessionsController.cs
@@ -88,8 +88,8 @@ namespace NuClear.VStore.Host.Controllers
         [ProducesResponseType(typeof(string), 422)]
         public async Task<IActionResult> SetupSession(
             [FromHeader(Name = Headers.HeaderNames.AmsAuthor)] string author,
-            long templateId,
-            Language language)
+            Language language,
+            long templateId)
         {
             if (string.IsNullOrEmpty(author))
             {
@@ -126,9 +126,9 @@ namespace NuClear.VStore.Host.Controllers
         [ProducesResponseType(typeof(string), 422)]
         public async Task<IActionResult> SetupSession(
             [FromHeader(Name = Headers.HeaderNames.AmsAuthor)] string author,
+            Language language,
             long templateId,
-            string templateVersionId,
-            Language language)
+            string templateVersionId)
         {
             if (string.IsNullOrEmpty(author))
             {

--- a/VStore.Host/Controllers/SessionsController.cs
+++ b/VStore.Host/Controllers/SessionsController.cs
@@ -52,17 +52,20 @@ namespace NuClear.VStore.Host.Controllers
                 Response.Headers[HeaderNames.ETag] = sessionId.ToString();
                 Response.Headers[HeaderNames.Expires] = sessionContext.ExpiresAt.ToString("R");
                 Response.Headers[Headers.HeaderNames.AmsAuthor] = sessionContext.Author;
-                return Json(new
-                {
-                    Template = new
-                    {
-                        Id = sessionContext.TemplateId,
-                        templateDescriptor.VersionId,
-                        templateDescriptor.Properties,
-                        templateDescriptor.Elements
-                    },
-                    uploadUrls
-                });
+                return Json(
+                    new
+                        {
+                            sessionContext.Language,
+                            Template = new
+                                           {
+                                               Id = sessionContext.TemplateId,
+                                               templateDescriptor.VersionId,
+                                               templateDescriptor.Author,
+                                               templateDescriptor.Properties,
+                                               templateDescriptor.Elements
+                                           },
+                            uploadUrls
+                        });
             }
             catch (ObjectNotFoundException ex)
             {
@@ -78,7 +81,7 @@ namespace NuClear.VStore.Host.Controllers
             }
         }
 
-        [HttpPost("{templateId}/{language}")]
+        [HttpPost("{language}/{templateId}")]
         [ProducesResponseType(201)]
         [ProducesResponseType(typeof(string), 400)]
         [ProducesResponseType(typeof(string), 404)]
@@ -96,7 +99,46 @@ namespace NuClear.VStore.Host.Controllers
             try
             {
                 var sessionId = Guid.NewGuid();
-                await _sessionManagementService.Setup(sessionId, templateId, language, author);
+                await _sessionManagementService.Setup(sessionId, templateId, null, language, author);
+                var url = Url.AbsoluteAction("Get", "Sessions", new { sessionId });
+
+                Response.Headers[HeaderNames.ETag] = sessionId.ToString();
+                return Created(url,  null);
+            }
+            catch (ObjectNotFoundException ex)
+            {
+                return NotFound(ex.Message);
+            }
+            catch (SessionCannotBeCreatedException ex)
+            {
+                return Unprocessable(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return InternalServerError(ex, "Unexpected error while setup session");
+            }
+        }
+
+        [HttpPost("{language}/{templateId}/{templateVersionId}")]
+        [ProducesResponseType(201)]
+        [ProducesResponseType(typeof(string), 400)]
+        [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(string), 422)]
+        public async Task<IActionResult> SetupSession(
+            [FromHeader(Name = Headers.HeaderNames.AmsAuthor)] string author,
+            long templateId,
+            string templateVersionId,
+            Language language)
+        {
+            if (string.IsNullOrEmpty(author))
+            {
+                return BadRequest($"'{Headers.HeaderNames.AmsAuthor}' request header must be specified.");
+            }
+
+            try
+            {
+                var sessionId = Guid.NewGuid();
+                await _sessionManagementService.Setup(sessionId, templateId, templateVersionId, language, author);
                 var url = Url.AbsoluteAction("Get", "Sessions", new { sessionId });
 
                 Response.Headers[HeaderNames.ETag] = sessionId.ToString();

--- a/VStore/Descriptors/Sessions/SessionContext.cs
+++ b/VStore/Descriptors/Sessions/SessionContext.cs
@@ -6,16 +6,18 @@ namespace NuClear.VStore.Descriptors.Sessions
 {
     public sealed class SessionContext
     {
-        public SessionContext(long templateId, IVersionedTemplateDescriptor templateDescriptor, string author, DateTime expiresAt)
+        public SessionContext(long templateId, IVersionedTemplateDescriptor templateDescriptor, Language language, string author, DateTime expiresAt)
         {
             TemplateId = templateId;
             TemplateDescriptor = templateDescriptor;
+            Language = language;
             Author = author;
             ExpiresAt = expiresAt;
         }
 
         public long TemplateId { get; }
         public IVersionedTemplateDescriptor TemplateDescriptor { get; }
+        public Language Language { get; }
         public string Author { get; }
         public DateTime ExpiresAt { get; }
     }

--- a/VStore/Sessions/SessionManagementService.cs
+++ b/VStore/Sessions/SessionManagementService.cs
@@ -62,17 +62,17 @@ namespace NuClear.VStore.Sessions
             var sessionDescriptor = (SessionDescriptor)sessionDescriptorWrapper;
             var templateDescriptor = await _templatesStorageReader.GetTemplateDescriptor(sessionDescriptor.TemplateId, sessionDescriptor.TemplateVersionId);
 
-            return new SessionContext(templateDescriptor.Id, templateDescriptor, sessionDescriptorWrapper.Author, sessionDescriptorWrapper.ExpiresAt);
+            return new SessionContext(templateDescriptor.Id, templateDescriptor, sessionDescriptor.Language, sessionDescriptorWrapper.Author, sessionDescriptorWrapper.ExpiresAt);
         }
 
-        public async Task Setup(Guid sessionId, long templateId, Language language, string author)
+        public async Task Setup(Guid sessionId, long templateId, string templateVersionId, Language language, string author)
         {
             if (language == Language.Unspecified)
             {
                 throw new SessionCannotBeCreatedException("Language must be explicitly specified.");
             }
 
-            var templateDescriptor = await _templatesStorageReader.GetTemplateDescriptor(templateId, null);
+            var templateDescriptor = await _templatesStorageReader.GetTemplateDescriptor(templateId, templateVersionId);
             var sessionDescriptor = new SessionDescriptor
                                         {
                                             TemplateId = templateDescriptor.Id,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/2gis/nuclear-vstore/14)
<!-- Reviewable:end -->
