### PR TITLE
Disabling 100-Continue and two-phase PUT operation

### DIFF
--- a/src/VStore/Objects/ObjectsManagementService.cs
+++ b/src/VStore/Objects/ObjectsManagementService.cs
@@ -290,11 +290,12 @@ namespace NuClear.VStore.Objects
             }
         }
 
-        private async Task<string> PutObject(long id,
-                                             string versionId,
-                                             AuthorInfo authorInfo,
-                                             IEnumerable<IObjectElementDescriptor> existingObjectElements,
-                                             IObjectDescriptor objectDescriptor)
+        private async Task<string> PutObject(
+            long id,
+            string versionId,
+            AuthorInfo authorInfo,
+            IEnumerable<IObjectElementDescriptor> existingObjectElements,
+            IObjectDescriptor objectDescriptor)
         {
             PreprocessObjectElements(objectDescriptor.Elements);
             await VerifyObjectElementsConsistency(id, objectDescriptor.Language, objectDescriptor.Elements);
@@ -303,7 +304,7 @@ namespace NuClear.VStore.Objects
             await _eventSender.SendAsync(_objectEventsTopic, new ObjectVersionCreatingEvent(id, versionId));
 
             var totalBinariesCount = 0;
-            PutObjectRequest putRequest;
+            ConsistentPutObjectRequest putRequest;
             MetadataCollectionWrapper metadataWrapper;
 
             foreach (var elementDescriptor in objectDescriptor.Elements)
@@ -311,7 +312,7 @@ namespace NuClear.VStore.Objects
                 var (elementPersistenceValue, binariesCount) = ConvertToPersistenceValue(elementDescriptor.Value, metadataForBinaries);
                 var elementPersistenceDescriptor = new ObjectElementPersistenceDescriptor(elementDescriptor, elementPersistenceValue);
                 totalBinariesCount += binariesCount;
-                putRequest = new PutObjectRequest
+                putRequest = new ConsistentPutObjectRequest
                     {
                         Key = id.AsS3ObjectKey(elementDescriptor.Id),
                         BucketName = _bucketName,
@@ -339,7 +340,7 @@ namespace NuClear.VStore.Objects
                     Properties = objectDescriptor.Properties,
                     Elements = elementVersions
                 };
-            putRequest = new PutObjectRequest
+            putRequest = new ConsistentPutObjectRequest
                 {
                     Key = objectKey,
                     BucketName = _bucketName,

--- a/src/VStore/S3/ConsistentPutObjectRequest.cs
+++ b/src/VStore/S3/ConsistentPutObjectRequest.cs
@@ -1,0 +1,9 @@
+﻿using Amazon.S3.Model;
+
+namespace NuClear.VStore.S3
+{
+    public sealed class ConsistentPutObjectRequest : PutObjectRequest
+    {
+        protected override bool Expect100Continue => false;
+    }
+}

--- a/src/VStore/S3/IS3Client.cs
+++ b/src/VStore/S3/IS3Client.cs
@@ -15,7 +15,7 @@ namespace NuClear.VStore.S3
         Task<GetObjectMetadataResponse> GetObjectMetadataAsync(string bucketName, string key, string versionId);
         Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, CancellationToken cancellationToken = default);
         Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = default);
-        Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request);
+        Task<PutObjectResponse> PutObjectAsync(ConsistentPutObjectRequest request);
         Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key);
         Task<CopyObjectResponse> CopyObjectAsync(CopyObjectRequest request);
     }

--- a/src/VStore/S3/S3Client.cs
+++ b/src/VStore/S3/S3Client.cs
@@ -39,7 +39,7 @@ namespace NuClear.VStore.S3
         async Task<GetObjectResponse> IS3Client.GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken)
             => await _amazonS3.GetObjectAsync(bucketName, key, versionId, cancellationToken);
 
-        async Task<PutObjectResponse> IS3Client.PutObjectAsync(PutObjectRequest request)
+        async Task<PutObjectResponse> IS3Client.PutObjectAsync(ConsistentPutObjectRequest request)
             => await _amazonS3.PutObjectAsync(request);
 
         async Task<DeleteObjectResponse> IS3Client.DeleteObjectAsync(string bucketName, string key)

--- a/src/VStore/S3/S3ClientPrometheusDecorator.cs
+++ b/src/VStore/S3/S3ClientPrometheusDecorator.cs
@@ -53,7 +53,7 @@ namespace NuClear.VStore.S3
         public async Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken)
             => await ExecuteS3Request(() => _s3Client.GetObjectAsync(bucketName, key, versionId, cancellationToken), bucketName);
 
-        public async Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request)
+        public async Task<PutObjectResponse> PutObjectAsync(ConsistentPutObjectRequest request)
             => await ExecuteS3Request(() => _s3Client.PutObjectAsync(request), request.BucketName);
 
         public async Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key)

--- a/src/VStore/S3/S3ClientProxy.cs
+++ b/src/VStore/S3/S3ClientProxy.cs
@@ -38,7 +38,7 @@ namespace NuClear.VStore.S3
         public async Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken)
             => await _s3Client.GetObjectAsync(bucketName, key, versionId, cancellationToken);
 
-        public async Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request)
+        public async Task<PutObjectResponse> PutObjectAsync(ConsistentPutObjectRequest request)
             => await _s3Client.PutObjectAsync(request);
 
         public async Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key)

--- a/src/VStore/Sessions/SessionManagementService.cs
+++ b/src/VStore/Sessions/SessionManagementService.cs
@@ -94,7 +94,7 @@ namespace NuClear.VStore.Sessions
                                             Language = language,
                                             BinaryElementTemplateCodes = templateDescriptor.GetBinaryElementTemplateCodes()
                                         };
-            var request = new PutObjectRequest
+            var request = new ConsistentPutObjectRequest
                               {
                                   BucketName = _filesBucketName,
                                   Key = sessionId.AsS3ObjectKey(Tokens.SessionPostfix),

--- a/src/VStore/Templates/TemplatesManagementService.cs
+++ b/src/VStore/Templates/TemplatesManagementService.cs
@@ -313,7 +313,7 @@ namespace NuClear.VStore.Templates
         {
             await VerifyElementDescriptorsConsistency(templateDescriptor.Elements);
 
-            var putRequest = new PutObjectRequest
+            var putRequest = new ConsistentPutObjectRequest
                 {
                     Key = id.ToString(),
                     BucketName = _bucketName,


### PR DESCRIPTION
The default AWS S3 SDK behaviour is to include `Expect: 100-continue` (see [here](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs#L406)), but that's not acceptable for us because of possible data corruption.